### PR TITLE
More endpoints

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(name='ubiquiti',
       version='0.2',
-      description='Library for interacting with Ubiquity Cloudkey',
+      description='Library for interacting with Unifi Cloudkey',
       url='http://github.com/vageli/Unifi-Python-API',
       author='vagelim',
       author_email='code@evangelosm.com',

--- a/ubiquiti/unifi.py
+++ b/ubiquiti/unifi.py
@@ -2,6 +2,7 @@
 """ Control a Unifi Controller via Python"""
 from requests import Session
 import json
+import os
 import re
 from typing import Pattern, Dict, Union
 
@@ -36,6 +37,10 @@ class API(object):
         self._verify_ssl = verify_ssl
         self._baseurl = baseurl
         self._session = Session()
+
+        if not verify_ssl and os.environ.get('IGNORE_SSL_WARNING', False):
+            import warnings
+            warnings.filterwarnings("ignore")  # Suppress SSL warnings
 
     def __enter__(self):
         """

--- a/ubiquiti/unifi.py
+++ b/ubiquiti/unifi.py
@@ -22,11 +22,11 @@ class API(object):
         """
         Initiates tha api with default settings if none other are set.
 
-        :param username: username for the controller user
-        :param password: password for the controller user
-        :param site: which site to connect to (Not the name you've given the site, but the url-defined name)
-        :param baseurl: where the controller is located
-        :param verify_ssl: Check if certificate is valid or not, throws warning if set to False
+        :param username: cloudkey username
+        :param password: cloudkey password
+        :param site: name of site (https://unifi:8443/manage/site/$THIS)
+        :param baseurl: controller URL
+        :param verify_ssl: Boolean to check the certificate validity (warns on False)
         """
         self._login_data['username'] = username
         self._login_data['password'] = password

--- a/ubiquiti/unifi.py
+++ b/ubiquiti/unifi.py
@@ -23,7 +23,7 @@ class API(object):
 
     def __init__(self, username: str="ubnt", password: str="ubnt", site: str="default", baseurl: str="https://unifi:8443", verify_ssl: bool=True):
         """
-        Initiates tha api with default settings if none other are set.
+        Initiate the api with defaults if unset.
 
         :param username: cloudkey username
         :param password: cloudkey password

--- a/ubiquiti/unifi.py
+++ b/ubiquiti/unifi.py
@@ -52,6 +52,12 @@ class API(object):
         """
         self.logout()
 
+    def _check_status_code(code):
+        status_codes = {400: "Invalid credentials",
+                        401: "Invalid login, or login has expired"}
+        if code in status_codes:
+            raise LoggedInException(status_codes[code])
+
     def login(self):
         """
         Log the user in.

--- a/ubiquiti/unifi.py
+++ b/ubiquiti/unifi.py
@@ -79,6 +79,9 @@ class API(object):
             data = [x for x in data if term in x.keys() and re.fullmatch(value_re, x[term])]
         return data
 
+    def _order_by(data, order_by):
+        return sorted(data, key=lambda x: x[order_by] if order_by in x.keys() else x['_id'])
+
     def login(self):
         """
         Log the user in.
@@ -155,7 +158,7 @@ class API(object):
             _filter(filters, data)
 
         if order_by:
-            data = sorted(data, key=lambda x: x[order_by] if order_by in x.keys() else x['_id'])
+            data = _order_by(data, order_by)
 
         return data
 
@@ -249,7 +252,7 @@ class API(object):
             self._filter(filters)
 
         if order_by:
-            data = sorted(data, key=lambda x: x[order_by] if order_by in x.keys() else x['_id'])
+            data = _order_by(data, order_by)
 
         return data
 
@@ -275,7 +278,7 @@ class API(object):
             data = _filter(filters, data)
 
         if order_by:
-            data = sorted(data, key=lambda x: x[order_by] if order_by in x.keys() else x['_id'])
+            data = _order_by(data, order_by)
 
         return data
 
@@ -305,7 +308,7 @@ class API(object):
             data = _filter(filters, data)
 
         if order_by:
-            data = sorted(data, key=lambda x: x[order_by] if order_by in x.keys() else x['_id'])
+            data = _order_by(data, order_by)
 
         return data
 
@@ -351,13 +354,13 @@ class API(object):
             data = _filter(filters, data)
 
         if order_by:
-            data = sorted(data, key=lambda x: x[order_by] if order_by in x.keys() else x['_id'])
+            data = _order_by(data, order_by)
 
         return data
 
     def list_sites(self, verbose=False, filters: Dict[str, Union[str, Pattern]]=None, order_by: str=None) -> list:
         """
-        Lists all sites on cloudkey.
+        List all sites on cloudkey.
 
         :param verbose: return more detailed information on each site
         :param filters: dict of k/v pairs; string is compiled to regex
@@ -384,7 +387,7 @@ class API(object):
             data = _filter(filters, data)
 
         if order_by:
-            data = sorted(data, key=lambda x: x[order_by] if order_by in x.keys() else x['_id'])
+            data = _order_by(data, order_by)
 
         return data
 
@@ -416,7 +419,7 @@ class API(object):
             data = _filter(filters, data)
 
         if order_by:
-            data = sorted(data, key=lambda x: x[order_by] if order_by in x.keys() else x['_id'])
+            data = _order_by(data, order_by)
 
         return data
 

--- a/ubiquiti/unifi.py
+++ b/ubiquiti/unifi.py
@@ -344,6 +344,38 @@ class API(object):
 
         return data
 
+    def list_sites(self, verbose=False, filters: Dict[str, Union[str, Pattern]]=None, order_by: str=None) -> list:
+        """
+        Lists all sites on cloudkey.
+
+        :param verbose: return more detailed information on each site
+        :param filters: dict of k/v pairs; string is compiled to regex
+        :param order_by: order by a key; defaults to '_id'
+        :return: A list of sites as dicts (see below)
+        _id: 98098be20fe9023d
+        attr_hidden_id: default
+        attr_no_delete: True
+        desc: test site
+        name: default
+        role: readonly
+        """
+        if verbose:
+            level = 'stat'
+        else:
+            level = 'self'
+        r = self._session.get("{}/api/{}/sites".format(self._baseurl, level, verify=self._verify_ssl), data="json={}")
+        self._current_status_code = r.status_code
+        self._check_status_code(self._current_status_code)
+
+        data = r.json()['data']
+
+        if filters:
+            data = _filter(filters, data)
+
+        if order_by:
+            data = sorted(data, key=lambda x: x[order_by] if order_by in x.keys() else x['_id'])
+
+        return data
         if order_by:
             data = sorted(data, key=lambda x: x[order_by] if order_by in x.keys() else x['_id'])
 

--- a/ubiquiti/unifi.py
+++ b/ubiquiti/unifi.py
@@ -64,9 +64,8 @@ class API(object):
                         401: "Invalid login, or login has expired"}
         if code == 401:
             try:
-                api.login()
-            except ubiquiti.unifi.LoggedInException:
-                raise
+                self.login()
+            except LoggedInException:
         elif code in status_codes:
             raise LoggedInException(status_codes[code])
 

--- a/ubiquiti/unifi.py
+++ b/ubiquiti/unifi.py
@@ -70,6 +70,16 @@ class API(object):
         elif code in status_codes:
             raise LoggedInException(status_codes[code])
 
+    def _filter(self, filters: Dict[str, Union[str, Pattern]], data: list) -> list:
+        """
+        Apply a set of filters to data
+        """
+        for term, value in filters.items():
+                value_re = value if isinstance(value, Pattern) else re.compile(value)
+
+                data = [x for x in data if term in x.keys() and re.fullmatch(value_re, x[term])]
+        return data
+
     def login(self):
         """
         Log the user in.
@@ -103,10 +113,7 @@ class API(object):
         data = r.json()['data']
 
         if filters:
-            for term, value in filters.items():
-                value_re = value if isinstance(value, Pattern) else re.compile(value)
-
-                data = [x for x in data if term in x.keys() and re.fullmatch(value_re, x[term])]
+            _filter(filters, data)
 
         if order_by:
             data = sorted(data, key=lambda x: x[order_by] if order_by in x.keys() else x['_id'])
@@ -200,10 +207,7 @@ class API(object):
         data = r.json()['data']
 
         if filters:
-            for term, value in filters.items():
-                value_re = value if isinstance(value, Pattern) else re.compile(value)
-
-                data = [x for x in data if term in x.keys() and re.fullmatch(value_re, x[term])]
+            self._filter(filters)
 
         if order_by:
             data = sorted(data, key=lambda x: x[order_by] if order_by in x.keys() else x['_id'])
@@ -229,10 +233,7 @@ class API(object):
         data = r.json()['data']
 
         if filters:
-            for term, value in filters.items():
-                value_re = value if isinstance(value, Pattern) else re.compile(value)
-
-                data = [x for x in data if term in x.keys() and re.fullmatch(value_re, x[term])]
+            data = _filter(filters, data)
 
         if order_by:
             data = sorted(data, key=lambda x: x[order_by] if order_by in x.keys() else x['_id'])
@@ -262,10 +263,7 @@ class API(object):
         data = r.json()['data']
 
         if filters:
-            for term, value in filters.items():
-                value_re = value if isinstance(value, Pattern) else re.compile(value)
-
-                data = [x for x in data if term in x.keys() and re.fullmatch(value_re, x[term])]
+            data = _filter(filters, data)
 
         if order_by:
             data = sorted(data, key=lambda x: x[order_by] if order_by in x.keys() else x['_id'])
@@ -311,10 +309,12 @@ class API(object):
         data = r.json()['data']
 
         if filters:
-            for term, value in filters.items():
-                value_re = value if isinstance(value, Pattern) else re.compile(value)
+            data = _filter(filters, data)
 
-                data = [x for x in data if term in x.keys() and re.fullmatch(value_re, x[term])]
+        if order_by:
+            data = sorted(data, key=lambda x: x[order_by] if order_by in x.keys() else x['_id'])
+
+        return data
 
         if order_by:
             data = sorted(data, key=lambda x: x[order_by] if order_by in x.keys() else x['_id'])
@@ -345,10 +345,7 @@ class API(object):
         data = r.json()['data']
 
         if filters:
-            for term, value in filters.items():
-                value_re = value if isinstance(value, Pattern) else re.compile(value)
-
-                data = [x for x in data if term in x.keys() and re.fullmatch(value_re, x[term])]
+            data = _filter(filters, data)
 
         if order_by:
             data = sorted(data, key=lambda x: x[order_by] if order_by in x.keys() else x['_id'])

--- a/ubiquiti/unifi.py
+++ b/ubiquiti/unifi.py
@@ -5,16 +5,16 @@ from typing import Pattern, Dict, Union
 
 
 class LoggedInException(Exception):
+    """LoggedInException."""
 
     def __init__(self, *args, **kwargs):
+        """Init function for LoggedInException."""
         super(LoggedInException, self).__init__(*args, **kwargs)
 
 
 class API(object):
-    """
-    Unifi API for the Unifi Controller.
+    """Unifi API for the Unifi Controller."""
 
-    """
     _login_data = {}
     _current_status_code = None
 
@@ -26,7 +26,7 @@ class API(object):
         :param password: cloudkey password
         :param site: name of site (https://unifi:8443/manage/site/$THIS)
         :param baseurl: controller URL
-        :param verify_ssl: Boolean to check the certificate validity (warns on False)
+        :param verify_ssl: toggle check of ssl cert validity (warns on False)
         """
         self._login_data['username'] = username
         self._login_data['password'] = password

--- a/ubiquiti/unifi.py
+++ b/ubiquiti/unifi.py
@@ -65,8 +65,7 @@ class API(object):
         :return: None
         """
         self._current_status_code = self._session.post("{}/api/login".format(self._baseurl), data=json.dumps(self._login_data), verify=self._verify_ssl).status_code
-        if self._current_status_code == 400:
-            raise LoggedInException("Failed to log in to api with provided credentials")
+        self._check_status_code(self._current_status_code)
 
     def logout(self):
         """
@@ -85,12 +84,9 @@ class API(object):
         :param order_by: order by a key; defaults to '_id'
         :return: A list of clients on the format of a dict
         """
-
         r = self._session.get("{}/api/s/{}/stat/sta".format(self._baseurl, self._site, verify=self._verify_ssl), data="json={}")
         self._current_status_code = r.status_code
-
-        if self._current_status_code == 401:
-            raise LoggedInException("Invalid login, or login has expired")
+        self._check_status_code(self._current_status_code)
 
         data = r.json()['data']
 
@@ -108,9 +104,10 @@ class API(object):
     def health(self) -> dict:
         """
         List site health information.
+
         :return: A dict of network health information (see below)
         num_adopted
-        num_ap        
+        num_ap
         num_disabled
         num_disconnected
         num_guest
@@ -124,8 +121,7 @@ class API(object):
         """
         r = self._session.get("{}/api/s/{}/stat/health".format(self._baseurl, self._site, verify=False), data="json={}")
         self._current_status_code = r.status_code
-        if self._current_status_code == 401:
-            raise LoggedInException("Invalid login, or login has expired")
+        self._check_status_code(self._current_status_code)
 
         data = r.json()['data']
 
@@ -134,6 +130,7 @@ class API(object):
     def info(self) -> dict:
         """
         List site information.
+
         :return: A dict of site information (see below for a sample)
         autobackup
         build
@@ -154,8 +151,7 @@ class API(object):
         """
         r = self._session.get("{}/api/s/{}/stat/sysinfo".format(self._baseurl, self._site, verify=False), data="json={}")
         self._current_status_code = r.status_code
-        if self._current_status_code == 401:
-            raise LoggedInException("Invalid login, or login has expired")
+        self._check_status_code(self._current_status_code)
 
         data = r.json()['data']
 
@@ -187,9 +183,7 @@ class API(object):
         """
         r = self._session.get("{}/api/s/{}/stat/event".format(self._baseurl, self._site, verify=self._verify_ssl), data="json={}")
         self._current_status_code = r.status_code
-
-        if self._current_status_code == 401:
-            raise LoggedInException("Invalid login, or login has expired")
+        self._check_status_code(self._current_status_code)
 
         data = r.json()['data']
 
@@ -218,9 +212,7 @@ class API(object):
         """
         r = self._session.get("{}/api/s/{}/stat/routing".format(self._baseurl, self._site, verify=self._verify_ssl), data="json={}")
         self._current_status_code = r.status_code
-
-        if self._current_status_code == 401:
-            raise LoggedInException("Invalid login, or login has expired")
+        self._check_status_code(self._current_status_code)
 
         data = r.json()['data']
 
@@ -253,9 +245,7 @@ class API(object):
         """
         r = self._session.get("{}/api/s/{}/rest/portforward".format(self._baseurl, self._site, verify=self._verify_ssl), data="json={}")
         self._current_status_code = r.status_code
-
-        if self._current_status_code == 401:
-            raise LoggedInException("Invalid login, or login has expired")
+        self._check_status_code(self._current_status_code)
 
         data = r.json()['data']
 
@@ -304,9 +294,7 @@ class API(object):
         """
         r = self._session.get("{}/api/s/{}/stat/rogueap".format(self._baseurl, self._site, verify=self._verify_ssl), data="json={}")
         self._current_status_code = r.status_code
-
-        if self._current_status_code == 401:
-            raise LoggedInException("Invalid login, or login has expired")
+        self._check_status_code(self._current_status_code)
 
         data = r.json()['data']
 
@@ -340,9 +328,7 @@ class API(object):
         """
         r = self._session.get("{}/api/s/{}/rest/wlanconf".format(self._baseurl, self._site, verify=self._verify_ssl), data="json={}")
         self._current_status_code = r.status_code
-
-        if self._current_status_code == 401:
-            raise LoggedInException("Invalid login, or login has expired")
+        self._check_status_code(self._current_status_code)
 
         data = r.json()['data']
 

--- a/ubiquiti/unifi.py
+++ b/ubiquiti/unifi.py
@@ -376,6 +376,34 @@ class API(object):
             data = sorted(data, key=lambda x: x[order_by] if order_by in x.keys() else x['_id'])
 
         return data
+
+    def setting(self, filters: Dict[str, Union[str, Pattern]]=None, order_by: str=None) -> list:
+        """"
+        List device settings.
+
+        :param filters: dict of k/v pairs; string is compiled to regex
+        :param order_by: order by a key; defaults to '_id'
+        :return: A list of settings as dicts (see below for example, though 
+                 note that each list element is unique in terms of keys
+
+        _id
+        advanced_feature_enabled
+        alert_enabled
+        key
+        led_enabled
+        site_id
+        unifi_idp_enabled
+
+        """
+        r = self._session.get("{}/api/s/{}/rest/setting".format(self._baseurl, self._site, verify=self._verify_ssl), data="json={}")
+        self._current_status_code = r.status_code
+        self._check_status_code(self._current_status_code)
+
+        data = r.json()['data']
+
+        if filters:
+            data = _filter(filters, data)
+
         if order_by:
             data = sorted(data, key=lambda x: x[order_by] if order_by in x.keys() else x['_id'])
 

--- a/ubiquiti/unifi.py
+++ b/ubiquiti/unifi.py
@@ -52,10 +52,15 @@ class API(object):
         """
         self.logout()
 
-    def _check_status_code(code):
+    def _check_status_code(self,code):
         status_codes = {400: "Invalid credentials",
                         401: "Invalid login, or login has expired"}
-        if code in status_codes:
+        if code == 401:
+            try:
+                api.login()
+            except ubiquiti.unifi.LoggedInException:
+                raise
+        elif code in status_codes:
             raise LoggedInException(status_codes[code])
 
     def login(self):

--- a/ubiquiti/unifi.py
+++ b/ubiquiti/unifi.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-""" Control a Unifi Controller via Python"""
+""" Control a Unifi Controller via Python."""
 from requests import Session
 import json
 import os
@@ -59,7 +59,7 @@ class API(object):
         """
         self.logout()
 
-    def _check_status_code(self,code):
+    def _check_status_code(self, code):
         status_codes = {400: "Invalid credentials",
                         401: "Invalid login, or login has expired",
                         403: "Current user not authorized to perform action"}
@@ -72,13 +72,11 @@ class API(object):
             raise LoggedInException(status_codes[code])
 
     def _filter(self, filters: Dict[str, Union[str, Pattern]], data: list) -> list:
-        """
-        Apply a set of filters to data
-        """
+        """Apply a set of filters to data."""
         for term, value in filters.items():
-                value_re = value if isinstance(value, Pattern) else re.compile(value)
+            value_re = value if isinstance(value, Pattern) else re.compile(value)
 
-                data = [x for x in data if term in x.keys() and re.fullmatch(value_re, x[term])]
+            data = [x for x in data if term in x.keys() and re.fullmatch(value_re, x[term])]
         return data
 
     def login(self):

--- a/ubiquiti/unifi.py
+++ b/ubiquiti/unifi.py
@@ -98,6 +98,34 @@ class API(object):
         self._session.get("{}/logout".format(self._baseurl))
         self._session.close()
 
+    def self(self) -> dict:
+        """
+        List data about the current caller.
+
+        :return: A dict of information about the caller (see below)
+        admin_id: 5bf09832e9875059b0390a9
+        device_id: FC000390839999902
+        email: none@none.com
+        email_alert_enabled: True
+        email_alert_grouping_delay: 60
+        email_alert_grouping_enabled: True
+        html_email_enabled: True
+        is_local: True
+        is_professional_installer: False
+        is_super: False
+        last_site_name: default
+        name: monitoring
+        requires_new_password: False
+        super_site_permissions: ['API_STAT_DEVICE_ACCESS_SUPER_SITE_PENDING', 'API_WIDGET_OS_STATS']
+        ui_settings: {'dashboardConfig': {'lastActiveDashboardId': '5bf09832e9875059b0390a9'}}
+        """
+        r = self._session.get("{}/api/self".format(self._baseurl, self._site, verify=self._verify_ssl), data="json={}")
+        self._current_status_code = r.status_code
+        self._check_status_code(self._current_status_code)
+
+        data = r.json()['data']
+        return data[0]
+
     def list_clients(self, filters: Dict[str, Union[str, Pattern]]=None, order_by: str=None) -> list:
         """
         List all available clients from the api.

--- a/ubiquiti/unifi.py
+++ b/ubiquiti/unifi.py
@@ -97,6 +97,18 @@ class API(object):
         self._session.get("{}/logout".format(self._baseurl))
         self._session.close()
 
+    def backup(self) -> None:
+        """Backup settings to a fixed location on filesystem. (Where?!)."""
+        payload = {'cmd': 'backup'}
+        r = self._session.post(
+            "{}/api/s/{}/cmd/system".format(
+                self._baseurl, self._site),
+            data=payload,
+            verify=self._verify_ssl)
+        self._current_status_code = r.status_code
+        if r.status_code == 401:
+            self._check_status_code(403)
+
     def self(self) -> dict:
         """
         List data about the current caller.

--- a/ubiquiti/unifi.py
+++ b/ubiquiti/unifi.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+""" Control a Unifi Controller via Python"""
 from requests import Session
 import json
 import re

--- a/ubiquiti/unifi.py
+++ b/ubiquiti/unifi.py
@@ -228,3 +228,89 @@ class API(object):
             data = sorted(data, key=lambda x: x[order_by] if order_by in x.keys() else x['_id'])
 
         return data
+
+    def port_forwarding(self, filters: Dict[str, Union[str, Pattern]]=None, order_by: str=None) -> list:
+        """
+        List forwarded ports.
+
+        :param filters: dict of k/v pairs; string is compiled to regex
+        :param order_by: order by a key; defaults to '_id'
+        :return: A list of forwarded ports as dicts (see below)
+        _id
+        dst_port
+        fwd
+        fwd_port
+        name
+        proto
+        site_id
+        src
+        """
+        r = self._session.get("{}/api/s/{}/rest/portforward".format(self._baseurl, self._site, verify=self._verify_ssl), data="json={}")
+        self._current_status_code = r.status_code
+
+        if self._current_status_code == 401:
+            raise LoggedInException("Invalid login, or login has expired")
+
+        data = r.json()['data']
+
+        if filters:
+            for term, value in filters.items():
+                value_re = value if isinstance(value, Pattern) else re.compile(value)
+
+                data = [x for x in data if term in x.keys() and re.fullmatch(value_re, x[term])]
+
+        if order_by:
+            data = sorted(data, key=lambda x: x[order_by] if order_by in x.keys() else x['_id'])
+
+        return data
+
+    def list_aps(self, filters: Dict[str, Union[str, Pattern]]=None, order_by: str=None) -> list:
+        """
+        List nearby access points (and identify potential rogue APs).
+
+        :param filters: dict of k/v pairs; string is compiled to regex
+        :param order_by: order by a key; defaults to '_id'
+        :return: A list of access_points as dicts (see below)
+        _id
+        age
+        ap_mac
+        band
+        bssid
+        bw
+        center_freq
+        channel
+        essid
+        freq
+        is_adhoc
+        is_rogue
+        is_ubnt
+        last_seen
+        noise
+        oui
+        radio
+        radio_name
+        report_time
+        rssi
+        rssi_age
+        security
+        signal
+        site_id
+        """
+        r = self._session.get("{}/api/s/{}/stat/rogueap".format(self._baseurl, self._site, verify=self._verify_ssl), data="json={}")
+        self._current_status_code = r.status_code
+
+        if self._current_status_code == 401:
+            raise LoggedInException("Invalid login, or login has expired")
+
+        data = r.json()['data']
+
+        if filters:
+            for term, value in filters.items():
+                value_re = value if isinstance(value, Pattern) else re.compile(value)
+
+                data = [x for x in data if term in x.keys() and re.fullmatch(value_re, x[term])]
+
+        if order_by:
+            data = sorted(data, key=lambda x: x[order_by] if order_by in x.keys() else x['_id'])
+
+        return data

--- a/ubiquiti/unifi.py
+++ b/ubiquiti/unifi.py
@@ -323,7 +323,7 @@ class API(object):
 
     def wlan_config(self, filters: Dict[str, Union[str, Pattern]]=None, order_by: str=None) -> list:
         """
-        List wireless configuration
+        List wireless configuration.
 
         :param filters: dict of k/v pairs; string is compiled to regex
         :param order_by: order by a key; defaults to '_id'

--- a/ubiquiti/unifi.py
+++ b/ubiquiti/unifi.py
@@ -314,3 +314,39 @@ class API(object):
             data = sorted(data, key=lambda x: x[order_by] if order_by in x.keys() else x['_id'])
 
         return data
+
+    def wlan_config(self, filters: Dict[str, Union[str, Pattern]]=None, order_by: str=None) -> list:
+        """
+        List wireless configuration
+
+        :param filters: dict of k/v pairs; string is compiled to regex
+        :param order_by: order by a key; defaults to '_id'
+        :return: A list of wlans as dicts (see below)
+        _id
+        enabled
+        hide_ssid
+        name
+        security
+        site_id
+        uapsd_enabled
+        wep_idx
+        wlangroup_id
+        """
+        r = self._session.get("{}/api/s/{}/rest/wlanconf".format(self._baseurl, self._site, verify=self._verify_ssl), data="json={}")
+        self._current_status_code = r.status_code
+
+        if self._current_status_code == 401:
+            raise LoggedInException("Invalid login, or login has expired")
+
+        data = r.json()['data']
+
+        if filters:
+            for term, value in filters.items():
+                value_re = value if isinstance(value, Pattern) else re.compile(value)
+
+                data = [x for x in data if term in x.keys() and re.fullmatch(value_re, x[term])]
+
+        if order_by:
+            data = sorted(data, key=lambda x: x[order_by] if order_by in x.keys() else x['_id'])
+
+        return data

--- a/ubiquiti/unifi.py
+++ b/ubiquiti/unifi.py
@@ -61,11 +61,13 @@ class API(object):
 
     def _check_status_code(self,code):
         status_codes = {400: "Invalid credentials",
-                        401: "Invalid login, or login has expired"}
+                        401: "Invalid login, or login has expired",
+                        403: "Current user not authorized to perform action"}
         if code == 401:
             try:
                 self.login()
             except LoggedInException:
+                raise LoggedInException(status_codes[code])
         elif code in status_codes:
             raise LoggedInException(status_codes[code])
 


### PR DESCRIPTION
## What does this do?
Adds a number of enhancements:
- `backup`: goodness knows _where_ this backup ends up, but it's ostensibly a cloudkey config backup
- `_check_status_code`: DRY-out error code checking and attempt re-login when 401 returned from API.
- `list_aps`: List neighboring APs.
- `list_sites`: List all sites managed by the cloudkey.
- `port_forwarding`: Return active port forwarding rules.
- `self`: Return information about the calling user.
- `settings`: Return cloudkey settings (like ntp server, timezone, hostname, etc).
- `wlan_config`: List current wireless configuration setting for the site.